### PR TITLE
Run SBOM upload on PRs and pushes to main

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -1,7 +1,10 @@
 name: Generate an SBOM from source code
 
 on:
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - 'main'
 
 jobs:
   generate-sbom:


### PR DESCRIPTION
To ensure there's an SBOM associated with merged commits, run the SBOM workflow on pushes to main. This will ensure that EdgeBit will produce a diff of dependency changes (and vulnerabilities) on future PRs.