### PR TITLE
Add repo-manifest input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,6 +24,9 @@ inputs:
   image-tag:
     description: 'Docker-style image tag to associate with the SBOM (eg "foo/bar:latest")'
     required: false
+  repo-digest:
+    description: 'Docker-style repo digest (or comma-separated list) to associate with the SBOM (eg "sha256:b644fed873ce1e623023d72a7ec6de626a834861c8bc724ce8e19a5138a8386e")'
+    required: false
   component:
     description: 'EdgeBit Component name to associate the SBOM with'
     required: false


### PR DESCRIPTION
Add `repo-manifest` as an expected input to the action. Previously this would be accepted but throw up a warning in the GitHub actions run.