### PR TITLE
Bump to NodeJS v20

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -52,5 +52,5 @@ branding:
   icon: zap
   color: blue
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
NodeJS v16 has been disabled and actions are now forced to run on v20.