### PR TITLE
Upgrade upload-artifact v2 to v4

### DIFF
--- a/.github/workflows/check-dist.yaml
+++ b/.github/workflows/check-dist.yaml
@@ -44,8 +44,9 @@ jobs:
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist
           path: dist/
+          overwrite: true


### PR DESCRIPTION
Adapt to changes in v4 now that v2 is deprecated and won't run.